### PR TITLE
Add thumbnail image to Nectarine streams list items.

### DIFF
--- a/default.py
+++ b/default.py
@@ -42,7 +42,8 @@ pluginConfig.read(os.path.join(os.path.dirname(__file__), "config.ini"))
 ARGS = urlparse.parse_qs(sys.argv[2][1:])
 BASE_URL = sys.argv[0]
 HANDLE = int(sys.argv[1])
-ADDON = xbmcaddon.Addon(id=pluginConfig.get('plugin', 'id'))
+ADDON_ID = pluginConfig.get('plugin', 'id')
+ADDON = xbmcaddon.Addon(ADDON_ID)
 
 
 class Main:
@@ -72,9 +73,10 @@ class Main:
 
         elif self.mode[0] == 'folder' and self.name[0] == 'streams':
 
+            thumbnailImage = 'special://home/addons/%s/icon.png' % ADDON_ID
             streams = self.get_streams()
             for stream in streams:
-                li = xbmcgui.ListItem(stream['name'], iconImage='DefaultAudio.png')
+                li = xbmcgui.ListItem(stream['name'], iconImage='DefaultAudio.png', thumbnailImage=thumbnailImage)
                 li.setInfo(type="Music", infoLabels={"Size": stream['bitrate'] * 1024})
                 li.setProperty("IsPlayable", "true")
                 xbmcplugin.addDirectoryItem(handle=HANDLE, url=stream['url'], listitem=li, isFolder=False)


### PR DESCRIPTION
This makes the Nectarine plugin logo show for Nectarine streams in your
favourites list. It makes it easier to identify a favourite as a Nectarine
radio station since only the name (ie "DE Stream (Max Bitrate)") could be
confusing.
