### PR TITLE
Migrate from scenemusic.net to scenestream.net hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Nectarine Demoscene Radio XBMC Plugin
 =====================================
 
-Stream the best of demoscene music from Nectarine Demoscene Radio (www.scenetream.net) directly from XBMC using this fan-made plugin.
+Stream the best of demoscene music from Nectarine Demoscene Radio (www.scenestream.net) directly from XBMC using this fan-made plugin.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Nectarine Demoscene Radio XBMC Plugin
 =====================================
 
-Stream the best of demoscene music from Nectarine Demoscene Radio (www.scenemusic.net) directly from XBMC using this fan-made plugin.
+Stream the best of demoscene music from Nectarine Demoscene Radio (www.scenetream.net) directly from XBMC using this fan-made plugin.

--- a/addon.xml
+++ b/addon.xml
@@ -17,7 +17,7 @@
 		<source>https://github.com/vidarw/xbmc.plugin.audio.nectarine.git</source>
    		<summary lang="en">Nectarine Demoscene Radio</summary>
 		<description lang="en">
-			Stream the best of demoscene music from Nectarine Demoscene Radio (www.scenemusic.net) directly from XBMC using this fan-made plugin.
+			Stream the best of demoscene music from Nectarine Demoscene Radio (www.scenestream.net) directly from XBMC using this fan-made plugin.
 		</description>
 	</extension>
 </addon>

--- a/config.ini
+++ b/config.ini
@@ -3,5 +3,5 @@
 id                  = plugin.audio.nectarine
 
 [urls]
-stream_xml          = https://www.scenemusic.net/demovibes/xml/streams/
-history_xml         = https://www.scenemusic.net/demovibes/xml/queue/
+stream_xml          = https://www.scenestream.net/demovibes/xml/streams/
+history_xml         = https://www.scenestream.net/demovibes/xml/queue/

--- a/default.py
+++ b/default.py
@@ -115,7 +115,7 @@ class Main:
         else:
 
             # Add items
-            url = 'http://no.scenemusic.net:9000/necta.m3u'
+            url = 'http://necta.pedroja.tech/necta192.mp3'
             li = xbmcgui.ListItem(ADDON.getLocalizedString(30199), iconImage='DefaultAudio.png')
 
 


### PR DESCRIPTION
The person hosting nectarine on scenemusic.net has abandonned his efforts. Some others have since picked up the pieces and created the latest incarnation of nectarine at the scenestream.net hostname.