### PR TITLE
Added SSL certificate check since it seems not to work fine in LibreElec

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.audio.nectarine"
        name="Nectarine Demoscene Radio"
-       version="1.0.2"
+       version="1.0.3"
        provider-name="Vidar Waagbo">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,11 @@
 * Fixed/improved feature
 - Removed feature
 
+2020-07-25 v1.0.3
+=================
+
++ Added SSL certificate check flag. It seems not to be liked by LibreElec on Raspberry Pi
+
 2014-05-01 v1.0.2
 =================
 

--- a/config.ini
+++ b/config.ini
@@ -1,7 +1,8 @@
 # Nectarine Demoscene Radio XBMC config
 [plugin]
 id                  = plugin.audio.nectarine
-
+ssl_check           = true
 [urls]
 stream_xml          = https://www.scenemusic.net/demovibes/xml/streams/
 history_xml         = https://www.scenemusic.net/demovibes/xml/queue/
+

--- a/httpcomm.py
+++ b/httpcomm.py
@@ -2,6 +2,7 @@ import zlib
 import httplib
 import urllib
 import urllib2
+import ssl
 import gzip
 import StringIO
 import cookielib
@@ -12,9 +13,15 @@ class HTTPComm:
     cj = None
     curlinstance = None
 
-    def __init__(self):
+    def __init__(self, ssl_check=False):
         self.cj = cookielib.CookieJar()
-        self.curlinstance = urllib2.build_opener(urllib2.HTTPCookieProcessor(self.cj))
+        if not ssl_check:
+          ctx = ssl.create_default_context()
+          ctx.check_hostname = False
+          ctx.verify_mode = ssl.CERT_NONE
+          self.curlinstance = urllib2.build_opener(urllib2.HTTPCookieProcessor(self.cj),urllib2.HTTPSHandler(context=ctx))
+        else:
+          self.curlinstance = urllib2.build_opener(urllib2.HTTPCookieProcessor(self.cj))
 
     def request(self, url, mode, postdata=None):
         timeout = 10


### PR DESCRIPTION
When using Kodi Leia on LibreeElec Raspberry Pi, demovibe's website certificate seems not trusted. There's a new flag added into config.ini file to enable or disable the check.